### PR TITLE
Update Bean Validation API to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <!-- see http://maven.apache.org/general.html -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <validation.api.version>3.0.0-M1</validation.api.version>
+        <validation.api.version>3.0.0</validation.api.version>
 
         <!-- What license to include in the dist binary. For Jakarta releases that are used to certify implementations, this
         must be the EFTL.txt file. Default is the Apache license. Override with -Dlicense.file=EFTL.txt in CI build of
@@ -111,7 +111,7 @@
 
         <!-- This is only needed for an example in the documentation; there is
              no dependency to the RI -->
-        <hibernate.validator.version>7.0.0.Alpha4</hibernate.validator.version>
+        <hibernate.validator.version>7.0.0.Alpha5</hibernate.validator.version>
 
         <testng.version>6.14.3</testng.version>
         <assertj-core.version>3.7.0</assertj-core.version>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/address-constraints-ConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/address-constraints-ConfigurationTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation=
-                "https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                "https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
                 version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.bootstrap.Address" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/validation-BootstrapCustomProviderDefinedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/validation-BootstrapCustomProviderDefinedInValidationXmlTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     version="3.0">
     <default-provider>org.hibernate.beanvalidation.tck.common.TCKValidationProvider</default-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/validation-BootstrapUnknownCustomProviderTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/customprovider/validation-BootstrapUnknownCustomProviderTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <default-provider>foo.bar.Provider</default-provider>
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/user-constraints-ConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/user-constraints-ConfigurationTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation=
-                "https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                "https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
         version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.bootstrap.User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
         
             <default-provider>com.acme.ValidationProvider</default-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithEmptyValidatedExecutableTypesTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithEmptyValidatedExecutableTypesTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingALLAndNONETest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingALLAndNONETest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingALLTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingALLTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingNONETest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingNONETest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingSomeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/bootstrap/validation-BootstrapConfigurationWithValidatedExecutableTypesContainingSomeTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/builtin-constraints-override.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/constraints/builtinconstraints/builtin-constraints-override.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <constraint-definition annotation="jakarta.validation.constraints.NotNull">
         <validated-by include-existing-validators="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/validation-DefaultInjectionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/validation-DefaultInjectionTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     version="3.0">
 
     <message-interpolator>org.hibernate.beanvalidation.tck.tests.integration.cdi.defaultinjection.ConstantMessageInterpolator</message-interpolator>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/validation-ExecutableValidationBasedOnGlobalConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/validation-ExecutableValidationBasedOnGlobalConfigurationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/globallydisabled/validation-ExecutableValidationGloballyDisabledTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/globallydisabled/validation-ExecutableValidationGloballyDisabledTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     version="3.0">
 
     <executable-validation enabled="false"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedObjectsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedObjectsTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
     <message-interpolator>org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.MessageInterpolatorUsingDependencyInjection</message-interpolator>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedValueExtractorsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedValueExtractorsTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.MapKeyValueExtractorUsingDependencyInjection</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedXmlAndServiceLoaderValueExtractorsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/validation-ManagedXmlAndServiceLoaderValueExtractorsTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.integration.cdi.managedobjects.MapKeyValueExtractorUsingDependencyInjection</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/ee/test-validation.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/integration/ee/test-validation.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <message-interpolator>org.hibernate.beanvalidation.tck.tests.integration.ee.ConstantMessageInterpolator</message-interpolator>
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/metadata/validation-ExecutableDescriptorIgnoresValidatedExecutableXmlSettingsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/metadata/validation-ExecutableDescriptorIgnoresValidatedExecutableXmlSettingsTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/methodvalidation/validation-ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/methodvalidation/validation-ExecutableValidationIgnoresValidatedExecutableXmlSettingsTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <executable-validation>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/multiple-value-extractors-for-same-type-and-type-argument-validation.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/multiple-value-extractors-for-same-type-and-type-argument-validation.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-        https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+        https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
     version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractor0</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractor-validation.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractor-validation.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-        https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+        https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
     version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractor</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractor-with-no-public-no-arg-constructor-validation.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractor-with-no-public-no-arg-constructor-validation.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-        https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+        https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
     version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractorWithNoPublicNoArgConstructor</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractors-precedence-validation.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/valueextraction/declaration/value-extractors-precedence-validation.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-    xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+    xmlns="https://jakarta.ee/xml/ns/validation/configuration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-        https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+        https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
     version="3.0">
 
     <value-extractor>org.hibernate.beanvalidation.tck.tests.valueextraction.declaration.model.ReferenceValueExtractor1</value-extractor>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingImplicitOverrideTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingImplicitOverrideTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.clazzlevel</default-package>
     <bean class="Package" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.clazzlevel</default-package>
     <bean class="Package">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingWithAnnotationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/clazzlevel/package-constraints-ClassLevelOverridingWithAnnotationTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.clazzlevel</default-package>
     <bean class="Package">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-ConfiguredBeanNotInClassPathTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-ConfiguredBeanNotInClassPathTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="Foo" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-GroupIsNotAllowedAsElementNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-GroupIsNotAllowedAsElementNameTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="User" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-MandatoryNameAttributeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-MandatoryNameAttributeTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="User" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-MessageIsNotAllowedAsElementNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-MessageIsNotAllowedAsElementNameTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="User" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-PayloadIsNotAllowedAsElementNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-PayloadIsNotAllowedAsElementNameTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="User" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareContainerElementCascades-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareContainerElementCascades-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-ignoreAnnotationsFalse-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-ignoreAnnotationsFalse-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-ignoreAnnotationsTrue-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-ignoreAnnotationsTrue-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/field-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareContainerElementCascades-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareContainerElementCascades-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-ignoreAnnotationsFalse-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-ignoreAnnotationsFalse-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-ignoreAnnotationsTrue-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-ignoreAnnotationsTrue-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/getter-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareContainerElementCascades-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareContainerElementCascades-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintOnNonGenericParameterCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-declaringContainerElementTypeConstraintOnNonGenericParameterCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-ignoreAnnotationsFalse-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-ignoreAnnotationsFalse-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-ignoreAnnotationsTrue-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-ignoreAnnotationsTrue-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/parameter-omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareContainerElementCascades-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareContainerElementCascades-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-ignoreAnnotationsFalse-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-ignoreAnnotationsFalse-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-ignoreAnnotationsTrue-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-ignoreAnnotationsTrue-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException-mapping.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/containerelementlevel/returnvalue-omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException-mapping.xml
@@ -7,10 +7,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.containerelementlevel</default-package>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-ExcludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-ExcludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.fieldlevel.User">
         <field name="firstname"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-FieldLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-FieldLevelOverridingTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping" version="3.0">
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping" version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.fieldlevel.User"
           ignore-annotations="false">
         <field name="firstname" ignore-annotations="true"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-IncludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-IncludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.fieldlevel.User"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-InvalidGroupConversionInFieldLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-InvalidGroupConversionInFieldLevelOverridingTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping" version="3.0">
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping" version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.fieldlevel
     </default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-WrongFieldNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-WrongFieldNameTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.fieldlevel.User"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-ExcludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-ExcludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-ExcludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-FieldLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-FieldLevelOverridingTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-FieldLevelOverridingTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-IncludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-IncludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-IncludeFieldLevelAnnotationsDueToBeanDefaultsTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-InvalidGroupConversionInFieldLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-InvalidGroupConversionInFieldLevelOverridingTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-InvalidGroupConversionInFieldLevelOverridingTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-WrongFieldNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/validation-WrongFieldNameTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/fieldlevel/user-constraints-WrongFieldNameTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConfigurationViaXmlAndAnnotationsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConfigurationViaXmlAndAnnotationsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="Package" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConstraintDeclarationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConstraintDeclarationTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="Package"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-DefaultSequenceDefinedInXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-DefaultSequenceDefinedInXmlTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="Package" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-MissingMandatoryElementTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-MissingMandatoryElementTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration</default-package>
     <bean class="Package" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-ExcludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-ExcludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.propertylevel.User">
         <getter name="firstname"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-IncludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-IncludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.propertylevel.User"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-InvalidGroupConversionInPropertyLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-InvalidGroupConversionInPropertyLevelOverridingTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping" version="3.0">
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping" version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.propertylevel
     </default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-PropertyLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-PropertyLevelOverridingTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping" version="3.0">
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping" version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.propertylevel.User"
           ignore-annotations="false">
         <getter name="firstname" ignore-annotations="true"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-WrongPropertyNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-WrongPropertyNameTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdeclaration.propertylevel.User"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-ExcludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-ExcludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-ExcludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-IncludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-IncludePropertyLevelAnnotationsDueToBeanDefaultsTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-InvalidGroupConversionInPropertyLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-InvalidGroupConversionInPropertyLevelOverridingTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-InvalidGroupConversionInPropertyLevelOverridingTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-PropertyLevelOverridingTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-PropertyLevelOverridingTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-PropertyLevelOverridingTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-WrongPropertyNameTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/validation-WrongPropertyNameTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/propertylevel/user-constraints-WrongPropertyNameTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConfigurationViaXmlAndAnnotationsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConfigurationViaXmlAndAnnotationsTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConfigurationViaXmlAndAnnotationsTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConfiguredBeanNotInClassPathTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConfiguredBeanNotInClassPathTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-ConfiguredBeanNotInClassPathTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConstraintDeclarationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-ConstraintDeclarationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-ConstraintDeclarationTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-DefaultSequenceDefinedInXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-DefaultSequenceDefinedInXmlTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-DefaultSequenceDefinedInXmlTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-MandatoryNameAttributeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-MandatoryNameAttributeTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/constraints-MandatoryNameAttributeTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-MissingMandatoryElementTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/validation-MissingMandatoryElementTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdeclaration/package-constraints-MissingMandatoryElementTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdefinition/constraint-definition-ExludeExistingValidatorsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdefinition/constraint-definition-ExludeExistingValidatorsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <constraint-definition annotation="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdefinition.Length">
         <validated-by include-existing-validators="false"/>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdefinition/constraint-definition-IncludeExistingValidatorsTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constraintdefinition/constraint-definition-IncludeExistingValidatorsTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <constraint-definition annotation="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constraintdefinition.Length">
         <validated-by include-existing-validators="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/CascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/CascadedValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation.Cascaded">
 

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/DisabledCascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/DisabledCascadedValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation.Cascaded">
 

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/customer-repository-constraints-ConstructorValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/customer-repository-constraints-ConstructorValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation</default-package>
     <bean class="CustomerRepository">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/customer-repository-constraints-UnknownConstructorValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/customer-repository-constraints-UnknownConstructorValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation</default-package>
     <bean class="CustomerRepository">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsInConstructorConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsInConstructorConfigurationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation.IgnoreAnnotations"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsOnConstructorTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsOnConstructorTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.constructorvalidation.IgnoreAnnotations"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-CascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-CascadedValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/CascadedValidationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-ConstructorValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-ConstructorValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/customer-repository-constraints-ConstructorValidationTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-DisabledCascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-DisabledCascadedValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/DisabledCascadedValidationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-IgnoreAnnotationsInConstructorConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-IgnoreAnnotationsInConstructorConfigurationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsInConstructorConfigurationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-IgnoreAnnotationsOnConstructorTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-IgnoreAnnotationsOnConstructorTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/ignore-annotations-IgnoreAnnotationsOnConstructorTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-UnknownConstructorValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/constructorvalidation/validation-UnknownConstructorValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/GroupConversionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/GroupConversionTest.xml
@@ -8,11 +8,11 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+            https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.groupconversion</default-package>
     <bean class="Groups">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/containerelement/XmlBasedContainerElementGroupConversionValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/containerelement/XmlBasedContainerElementGroupConversionValidationTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.validation.groupconversion.containerelement.RegisteredAddresses" ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/containerelement/validation-XmlBasedContainerElementGroupConversionValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/containerelement/validation-XmlBasedContainerElementGroupConversionValidationTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/containerelement/XmlBasedContainerElementGroupConversionValidationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/validation-GroupConversionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/validation-GroupConversionTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     version="3.0">
       <constraint-mapping>org/hibernate/beanvalidation/tck/tests/xmlconfiguration/groupconversion/GroupConversionTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/invalid/InvalidMappingXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/invalid/InvalidMappingXmlTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping
-            https://xmlns.jakarta.ee/xml/ns/validation/mapping/validation-mapping-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
         version="3.0">
 
         <invalid />

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/invalid/validation-InvalidValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/invalid/validation-InvalidValidationXmlTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
         <invalid />

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/CascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/CascadedValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation.Cascaded">
 

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/DisabledCascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/DisabledCascadedValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation.Cascaded">
 

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/MethodAsGetterAndMethodNodeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/MethodAsGetterAndMethodNodeTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation.CustomerRepository"
           ignore-annotations="true">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/customer-repository-constraints-MethodValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/customer-repository-constraints-MethodValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation</default-package>
     <bean class="CustomerRepository">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/customer-repository-constraints-UnknownMethodValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/customer-repository-constraints-UnknownMethodValidationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation</default-package>
     <bean class="CustomerRepository">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsInMethodConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsInMethodConfigurationTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation.IgnoreAnnotations"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsOnMethodTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsOnMethodTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <constraint-mappings
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd" version="3.0">
 
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.methodvalidation.IgnoreAnnotations"
           ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-CascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-CascadedValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/CascadedValidationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-DisabledCascadedValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-DisabledCascadedValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/DisabledCascadedValidationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-IgnoreAnnotationsInMethodConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-IgnoreAnnotationsInMethodConfigurationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsInMethodConfigurationTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-IgnoreAnnotationsOnMethodTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-IgnoreAnnotationsOnMethodTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/ignore-annotations-IgnoreAnnotationsOnMethodTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-MethodAsGetterAndMethodNodeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-MethodAsGetterAndMethodNodeTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <constraint-mapping>
         org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/MethodAsGetterAndMethodNodeTest.xml

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-MethodValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-MethodValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/customer-repository-constraints-MethodValidationTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-UnknownMethodValidationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/methodvalidation/validation-UnknownMethodValidationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/order-constraints-XmlConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/order-constraints-XmlConfigurationTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="Order" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/order-constraints.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/order-constraints.xml
@@ -8,7 +8,7 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
 </constraint-mappings>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/superuser-constraints.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/superuser-constraints.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="SuperUser" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MissingClassNameOnBeanNodeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MissingClassNameOnBeanNodeTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleBeanDefinitionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleBeanDefinitionTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleFieldDefinitionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleFieldDefinitionTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleGetterDefinitionTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MultipleGetterDefinitionTest.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints.xml
@@ -8,8 +8,8 @@
 
 -->
 <constraint-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-                     xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+                     xmlns="https://jakarta.ee/xml/ns/validation/mapping"
                      version="3.0">
     <default-package>org.hibernate.beanvalidation.tck.tests.xmlconfiguration</default-package>
     <bean class="User" ignore-annotations="false">

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ClockProviderSpecifiedInValidationXmlNoDefaultConstructorTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ClockProviderSpecifiedInValidationXmlNoDefaultConstructorTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
         <clock-provider>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedClockProviderWithNoDefaultConstructor</clock-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ClockProviderSpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ClockProviderSpecifiedInValidationXmlTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
 
         <clock-provider>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedClockProvider</clock-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ConstraintValidatorFactorySpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ConstraintValidatorFactorySpecifiedInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <constraint-validator-factory>
         org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedConstraintValidatorFactory

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-DefaultProviderSpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-DefaultProviderSpecifiedInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
     <default-provider>org.hibernate.beanvalidation.tck.common.TCKValidationProvider</default-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MessageInterpolatorSpecifiedInValidationXmlNoDefaultConstructorTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MessageInterpolatorSpecifiedInValidationXmlNoDefaultConstructorTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <message-interpolator>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedMessageInterpolator.NoDefaultConstructorInterpolator</message-interpolator>
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MessageInterpolatorSpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MessageInterpolatorSpecifiedInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <message-interpolator>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedMessageInterpolator</message-interpolator>
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MissingClassNameOnBeanNodeTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-MissingClassNameOnBeanNodeTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-    xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     version="3.0">
       <constraint-mapping>org/hibernate/beanvalidation/tck/tests/xmlconfiguration/user-constraints-MissingClassNameOnBeanNodeTest.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ParameterNameProviderSpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-ParameterNameProviderSpecifiedInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
 
         <parameter-name-provider>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.CustomParameterNameProvider</parameter-name-provider>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-TraversableResolverSpecifiedInValidationXmlNoDefaultConstructorTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-TraversableResolverSpecifiedInValidationXmlNoDefaultConstructorTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <traversable-resolver>
         org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedTraversableResolver.NoDefaultConstructorResolver

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-TraversableResolverSpecifiedInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-TraversableResolverSpecifiedInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
         version="3.0">
     <traversable-resolver>org.hibernate.beanvalidation.tck.tests.xmlconfiguration.XmlDefinedTraversableResolver</traversable-resolver>
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-XmlConfigurationTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/validation-XmlConfigurationTest.xml
@@ -7,8 +7,8 @@
     See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
-<validation-config xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
-                   xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
+<validation-config xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration validation-configuration-3.0.xsd"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.0">
     <constraint-mapping>org/hibernate/beanvalidation/tck/tests/xmlconfiguration/order-constraints.xml</constraint-mapping>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/UnknownVersionInMappingXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/UnknownVersionInMappingXmlTest.xml
@@ -9,7 +9,7 @@
 -->
 <constraint-mappings
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         version="1.2">
 </constraint-mappings>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/Version30InMappingXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/Version30InMappingXmlTest.xml
@@ -9,8 +9,8 @@
 -->
 <constraint-mappings
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/mapping"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping validation-mapping-3.0.xsd"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
         version="3.0">
     <bean class="org.hibernate.beanvalidation.tck.tests.xmlconfiguration.versioning.TestEntity"/>
 </constraint-mappings>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/validation-UnknownVersionInValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/validation-UnknownVersionInValidationXmlTest.xml
@@ -8,9 +8,9 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="1.2">
 </validation-config>

--- a/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/validation-Version30InValidationXmlTest.xml
+++ b/tests/src/main/resources/org/hibernate/beanvalidation/tck/tests/xmlconfiguration/versioning/validation-Version30InValidationXmlTest.xml
@@ -8,10 +8,10 @@
 
 -->
 <validation-config
-        xmlns="https://xmlns.jakarta.ee/xml/ns/validation/configuration"
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://xmlns.jakarta.ee/xml/ns/validation/configuration
-            https://xmlns.jakarta.ee/xml/ns/validation/configuration/validation-configuration-3.0.xsd"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
         version="3.0">
     <clock-provider>
         org.hibernate.beanvalidation.tck.tests.xmlconfiguration.versioning.DummyClockProvider


### PR DESCRIPTION
Also update the XML namespaces to use the final ones.

@starksm64 I was looking at updating HV and I need the XML namespaces to be pushed to the TCK thus this PR.

If we are sure these are the final namespaces, we should include this PR and release a new TCK release so that I can release a corresponding Hibernate Validator.