### PR TITLE
Add support for CDI 4

### DIFF
--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/DefaultInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/defaultinjection/DefaultInjectionTest.java
@@ -55,7 +55,7 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 		return webArchiveBuilder()
 				.withTestClassPackage( DefaultInjectionTest.class )
 				.withValidationXml( "validation-DefaultInjectionTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/ExecutableValidationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/ExecutableValidationTest.java
@@ -85,7 +85,7 @@ public class ExecutableValidationTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ExecutableValidationTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/global/ExecutableValidationBasedOnGlobalConfigurationTest.java
@@ -39,7 +39,7 @@ public class ExecutableValidationBasedOnGlobalConfigurationTest extends Abstract
 		return webArchiveBuilder()
 				.withTestClassPackage( ExecutableValidationBasedOnGlobalConfigurationTest.class )
 				.withValidationXml( "validation-ExecutableValidationBasedOnGlobalConfigurationTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/globallydisabled/ExecutableValidationGloballyDisabledTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/globallydisabled/ExecutableValidationGloballyDisabledTest.java
@@ -34,7 +34,7 @@ public class ExecutableValidationGloballyDisabledTest extends AbstractTCKTest {
 		return webArchiveBuilder()
 				.withTestClassPackage( ExecutableValidationGloballyDisabledTest.class )
 				.withValidationXml( "validation-ExecutableValidationGloballyDisabledTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/ValidationInterceptorPriorityTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/priority/ValidationInterceptorPriorityTest.java
@@ -41,7 +41,7 @@ public class ValidationInterceptorPriorityTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ValidationInterceptorPriorityTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/types/ExecutableTypesTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/executable/types/ExecutableTypesTest.java
@@ -60,7 +60,7 @@ public class ExecutableTypesTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ExecutableTypesTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/factory/ConstraintValidatorInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/factory/ConstraintValidatorInjectionTest.java
@@ -39,7 +39,7 @@ public class ConstraintValidatorInjectionTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ConstraintValidatorInjectionTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedObjectsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedObjectsTest.java
@@ -52,7 +52,7 @@ public class ManagedObjectsTest extends AbstractTCKTest {
 		return webArchiveBuilder()
 				.withTestClassPackage( ManagedObjectsTest.class )
 				.withValidationXml( "validation-ManagedObjectsTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedServiceLoaderValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedServiceLoaderValueExtractorsTest.java
@@ -46,7 +46,7 @@ public class ManagedServiceLoaderValueExtractorsTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ManagedServiceLoaderValueExtractorsTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.withResource(
 						"jakarta.validation.valueextraction.ValueExtractor",
 						"META-INF/services/jakarta.validation.valueextraction.ValueExtractor",

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedValueExtractorsTest.java
@@ -47,7 +47,7 @@ public class ManagedValueExtractorsTest extends AbstractTCKTest {
 		return webArchiveBuilder()
 				.withTestClassPackage( ManagedValueExtractorsTest.class )
 				.withValidationXml( "validation-ManagedValueExtractorsTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedXmlAndServiceLoaderValueExtractorsTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/cdi/managedobjects/ManagedXmlAndServiceLoaderValueExtractorsTest.java
@@ -46,7 +46,7 @@ public class ManagedXmlAndServiceLoaderValueExtractorsTest extends AbstractTCKTe
 		return webArchiveBuilder()
 				.withTestClassPackage( ManagedXmlAndServiceLoaderValueExtractorsTest.class )
 				.withValidationXml( "validation-ManagedXmlAndServiceLoaderValueExtractorsTest.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.withResource(
 						"jakarta.validation.valueextraction.ValueExtractor-throwsException",
 						"META-INF/services/jakarta.validation.valueextraction.ValueExtractor",

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/DefaultInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/DefaultInjectionTest.java
@@ -37,7 +37,7 @@ public class DefaultInjectionTest extends AbstractTCKTest {
 				.withClass( Foo.class )
 				.withClass( ValidationTestEjb.class )
 				.withValidationXml( "test-validation.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/JndiRetrievalTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/JndiRetrievalTest.java
@@ -42,7 +42,7 @@ public class JndiRetrievalTest extends AbstractTCKTest {
 				.withClass( ConstantMessageInterpolator.class )
 				.withClass( Foo.class )
 				.withValidationXml( "test-validation.xml" )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/cdi/ConstraintValidatorInjectionTest.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/tests/integration/ee/cdi/ConstraintValidatorInjectionTest.java
@@ -36,7 +36,7 @@ public class ConstraintValidatorInjectionTest extends AbstractTCKTest {
 	public static WebArchive createTestArchive() {
 		return webArchiveBuilder()
 				.withTestClassPackage( ConstraintValidatorInjectionTest.class )
-				.withEmptyBeansXml()
+				.withBeansXml()
 				.build();
 	}
 

--- a/tests/src/main/java/org/hibernate/beanvalidation/tck/util/shrinkwrap/WebArchiveBuilder.java
+++ b/tests/src/main/java/org/hibernate/beanvalidation/tck/util/shrinkwrap/WebArchiveBuilder.java
@@ -27,6 +27,11 @@ import org.jboss.shrinkwrap.descriptor.api.webcommon30.WebAppVersionType;
  */
 public class WebArchiveBuilder extends ArchiveBuilder<WebArchiveBuilder, WebArchive> {
 
+	private static String BEANS_XML = "<beans xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" " +
+			"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+			"xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd\"\n" +
+			"bean-discovery-mode=\"all\"></beans>";
+
 	private List<ResourceDescriptor> webInfResources = null;
 
 	@Override
@@ -61,6 +66,10 @@ public class WebArchiveBuilder extends ArchiveBuilder<WebArchiveBuilder, WebArch
 	@Override
 	public WebArchiveBuilder withEmptyBeansXml() {
 		return withWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
+	}
+
+	public WebArchiveBuilder withBeansXml() {
+		return withWebInfResource(new StringAsset(BEANS_XML), "beans.xml");
 	}
 
 	private WebArchiveBuilder withWebInfResource(Asset asset, String target) {


### PR DESCRIPTION
CDI 4 changes how empty beans.xml is interpreted. This change adds a new
method to add a beans.xml that preserves CDI 3 behavior. The resulting
tests will behave the same under CDI 3 and 4.